### PR TITLE
Tortoise websockets transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       elixir: 1.8
     - otp_release: 22.0
       elixir: 1.8
+    - otp_release: 22.0
+      elixir: 1.9
 install:
   - mix local.hex --force
   - mix local.rebar

--- a/README.md
+++ b/README.md
@@ -14,3 +14,23 @@ def deps do
   ]
 end
 ```
+
+## Usage
+
+To connect to a MQTT server using websockets you need to do the following:
+
+```elixir
+Tortoise.Supervisor.start_child(
+    client_id: "my_client_id",
+    handler: {Tortoise.Handler.Logger, []},
+    server: {Tortoise.Transport.Websocket, host: 'localhost', port: 80},
+    subscriptions: [{"foo/bar", 0}])
+```
+
+Besides `:host` and `:port` options you can set the following optional options:
+
+* `:transport` - An atom with the transport protocol, either `:tcp` or `:tls`, defaults to `:tcp`
+* `:path` - A string with the websocket server path, defaults to `"/"`
+* `:headers` - A list of tuples with the HTTP headers to send to the server, defaults to `[]`
+* `:active` - A boolean or atom to indicate if the client should send back any received data, it can be `true`, `false` and `:once`, defaults to `false`
+* `:compress` - A boolean to indicate if the data should be compressed, defaults to `true`

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,5 @@
 use Mix.Config
+
+if Mix.env() == :test do
+  config :logger, level: :error
+end

--- a/lib/tortoise/transport/websocket.ex
+++ b/lib/tortoise/transport/websocket.ex
@@ -1,0 +1,149 @@
+defmodule Tortoise.Transport.Websocket do
+  @moduledoc false
+
+  @behaviour Tortoise.Transport
+
+  alias Tortoise.Transport
+  alias TortoiseWebsocket.Client
+
+  @impl true
+  def new(opts) do
+    {host, opts} = Keyword.pop(opts, :host)
+    {port, opts} = Keyword.pop(opts, :port, 8883)
+    host = coerce_host(host)
+    %Transport{type: __MODULE__, host: host, port: port, opts: opts}
+  end
+
+  defp coerce_host(host) when is_binary(host) do
+    String.to_charlist(host)
+  end
+
+  defp coerce_host(host) when is_tuple(host) do
+    :inet.ntoa(host)
+  end
+
+  defp coerce_host(otherwise) do
+    otherwise
+  end
+
+  @impl true
+  def connect(host, port, opts, timeout) do
+    opts =
+      Enum.map(opts, fn
+        {:tls, true} -> {:transport, :tls}
+        {:tls, false} -> {:transport, :tcp}
+        opt -> opt
+      end)
+
+    Client.connect(host, port, opts, timeout)
+  end
+
+  @impl true
+  def recv(socket, length, timeout) do
+    Client.recv(socket, length, timeout)
+  end
+
+  @impl true
+  def send(socket, data) do
+    data =
+      cond do
+        is_list(data) -> :erlang.list_to_binary(data)
+        true -> data
+      end
+
+    case socket do
+      %Client.Socket{} -> Client.send(socket, data)
+      %Socket.Web{} -> Socket.Web.send(socket, {:binary, data})
+    end
+  end
+
+  @impl true
+  def setopts(socket, opts) do
+    case socket do
+      %Client.Socket{} ->
+        active = Keyword.get(opts, :active, false)
+        Client.set_active(socket, active)
+
+      %Socket.Web{socket: socket} ->
+        opts =
+          Enum.map(opts, fn
+            :binary -> {:as, :binary}
+            {:active, false} -> {:mode, :passive}
+            {:active, true} -> {:mode, :active}
+            {:active, :once} -> {:mode, :once}
+            opt -> opt
+          end)
+
+        Socket.TCP.options(socket, opts)
+    end
+  end
+
+  @impl true
+  def getopts(_socket, _opts) do
+    throw("Not implemented")
+  end
+
+  @impl true
+  def getstat(_socket) do
+    throw("Not implemented")
+  end
+
+  @impl true
+  def getstat(_socket, _opt_names) do
+    throw("Not implemented")
+  end
+
+  @impl true
+  def controlling_process(socket, pid) do
+    Client.controlling_process(socket, pid)
+  end
+
+  @impl true
+  def peername(%Socket.Web{socket: socket}) do
+    :inet.peername(socket)
+  end
+
+  @impl true
+  def sockname(%Socket.Web{socket: socket}) do
+    :inet.sockname(socket)
+  end
+
+  @impl true
+  def shutdown(_socket, _mode) do
+    throw("Not implemented")
+  end
+
+  @impl true
+  def close(socket) do
+    case socket do
+      %Client.Socket{} -> Client.close(socket)
+      %Socket.Web{} -> Socket.Web.close(socket)
+    end
+  end
+
+  @impl true
+  def listen(opts) do
+    opts =
+      Enum.map(opts, fn
+        :binary -> {:as, :binary}
+        {:active, false} -> {:mode, :passive}
+        {:active, true} -> {:mode, :active}
+        {:active, :once} -> {:mode, :once}
+        opt -> opt
+      end)
+
+    Socket.Web.listen(0, opts)
+  end
+
+  @impl true
+  def accept(listen_socket, _timeout) do
+    {:ok, client} = Socket.Web.accept(listen_socket)
+    Socket.Web.accept!(client)
+    {:ok, client}
+  end
+
+  @impl true
+  def accept_ack(_socket, _timeout) do
+    :ok
+  end
+end

--- a/lib/tortoise_websocket/application.ex
+++ b/lib/tortoise_websocket/application.ex
@@ -4,7 +4,9 @@ defmodule TortoiseWebsocket.Application do
   use Application
 
   def start(_type, _args) do
-    children = []
+    children = [
+      TortoiseWebsocket.Client.Supervisor
+    ]
 
     opts = [strategy: :one_for_one, name: TortoiseWebsocket.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/tortoise_websocket/client.ex
+++ b/lib/tortoise_websocket/client.ex
@@ -1,0 +1,456 @@
+defmodule TortoiseWebsocket.Client do
+  @moduledoc ~S"""
+  A Websocket client with a API similar to `:gen_tcp`.
+
+  Example of usage where a client is started and connected, then it is used to send and receive
+  data:
+      iex> {:ok, socket} = TortoiseWebsocket.Client.connect('example.com', 80, [])
+      iex> :ok = TortoiseWebsocket.Client.send(socket, "data")
+      iex> {:ok, data} = TortoiseWebsocket.Client.recv(socket, 100)
+
+  When the client has the option `:active` set to `true` or `:once` it will send to the process
+  that started the client or the controlling process defined with `controlling_process/2` function
+  messages with the format `{:websocket, socket, data}`, where `socket` is the client socket struct
+  and `data` is a binary with the data received from the websocket server. If the the `:active`
+  option was set to `:once` the client will set it to `false` after sending data once. When the
+  option is set to `false`, the `recv/3` function must be used to retrieve data or the option needs
+  to be set back to `true` or `:once` using the `set_active/2` function.
+
+  When the connection is lost unexpectedly a message is sent with the format
+  `{:websocket_closed, socket}`.
+
+  To close the client connection to the websocket server the function `close/1` can be used, the
+  connection to the websocket will be closed and the client process will be stopped.
+  """
+
+  use GenStateMachine, restart: :transient
+  alias __MODULE__, as: Data
+  alias __MODULE__.Socket
+  alias :gun, as: Gun
+  require Logger
+
+  defstruct host: nil,
+            port: nil,
+            timeout: nil,
+            owner: nil,
+            owner_monitor_ref: nil,
+            transport: nil,
+            path: nil,
+            headers: nil,
+            ws_opts: nil,
+            active: nil,
+            caller: nil,
+            socket: nil,
+            buffer: "",
+            recv_queue: :queue.new()
+
+  @type reason() :: any()
+  @type opts() :: Keyword.t()
+
+  def start_link(args) do
+    GenStateMachine.start_link(__MODULE__, args)
+  end
+
+  @doc """
+  Starts and connects a client to the websocket server.
+
+  The `opts` paramameter is a Keyword list that expects the follwing optional entries:
+
+  * `:transport - An atom with the transport protocol, either `:tcp` or `:tls`, defaults to `:tcp`
+  * `:path` - A string with the websocket server path, defaults to `"/"`
+  * `:headers` - A list of tuples with the HTTP headers to send to the server, defaults to `[]`
+  * `:active` - A boolean or atom to indicate if the client should send back any received data, it
+  can be `true`, `false` and `:once`, defaults to `false`
+  * `:compress` - A boolean to indicate if the data should be compressed, defaults to `true`
+  """
+  @spec connect(charlist(), :inet.port_number(), opts(), timeout()) ::
+          {:ok, Socket.t()} | {:error, reason()}
+  def connect(host, port, opts \\ [], timeout \\ 5_000)
+      when (is_list(host) or is_atom(host) or is_tuple(host)) and (is_integer(port) and port > 0) and
+             is_list(opts) and is_integer(timeout) and timeout > 0 do
+    case TortoiseWebsocket.Client.Supervisor.start_child({self(), host, port, opts, timeout}) do
+      {:ok, pid} -> GenStateMachine.call(pid, :connect)
+      error -> error
+    end
+  end
+
+  @doc """
+  Sends data to the websocket server.
+
+  Data must be a binary or a list of binaries.
+  """
+  @spec send(Socket.t(), iodata()) :: :ok | {:error, reason()}
+  def send(%Socket{pid: pid}, data) when is_binary(data) or is_list(data) do
+    GenStateMachine.call(pid, {:send, data})
+  catch
+    :exit, _ -> {:error, :closed}
+  end
+
+  @doc """
+  When the client has the option `:active` set to `false`, the `recv/3` function can be used to
+  retrieve any data sent by the server.
+
+  If the provided length is `0`, it returns immediately with all data present in the client, even if
+  there is none. If the timeout expires it returns `{:error, :timeout}`.
+  """
+  @spec recv(Socket.t(), non_neg_integer(), timeout()) :: {:ok, any()} | {:error, reason()}
+  def recv(%Socket{pid: pid}, length, timeout \\ 5_000)
+      when is_integer(length) and length >= 0 and is_integer(timeout) and timeout > 0 do
+    GenStateMachine.call(pid, {:recv, length, timeout})
+  catch
+    :exit, _ -> {:error, :closed}
+  end
+
+  @doc """
+  Defines the process to which the data received by the client is sent to, when the client option
+  `:active` is set to `true` or `:once`.
+  """
+  @spec controlling_process(Socket.t(), pid()) :: :ok | {:error, reason()}
+  def controlling_process(%Socket{pid: pid}, new_owner_pid) when is_pid(new_owner_pid) do
+    GenStateMachine.call(pid, {:owner, new_owner_pid})
+  catch
+    :exit, _ -> {:error, :closed}
+  end
+
+  @doc """
+  Closes the client connection to the websocket server and stops the client. Any data retained by
+  the client will be lost.
+  """
+  @spec close(Socket.t()) :: :ok
+  def close(%Socket{pid: pid}) do
+    GenStateMachine.call(pid, :close)
+  catch
+    :exit, _ -> {:error, :closed}
+  end
+
+  @doc """
+  It defines the client `:active` option.
+
+  The possible values for the `:active` options are `true`, `false` or `:once`. When the `:active`
+  option is set to `:once`, the client will send back the first received frame of data and set the
+  `:active` option to `false`.
+  """
+  @spec set_active(Socket.t(), boolean | :once) :: :ok | {:error, reason()}
+  def set_active(%Socket{pid: pid}, active) when is_boolean(active) or active == :once do
+    GenStateMachine.call(pid, {:set_active, active})
+  catch
+    :exit, _ -> {:error, :closed}
+  end
+
+  def init({owner, host, port, opts, timeout}) do
+    Process.flag(:trap_exit, true)
+    ref = Process.monitor(owner)
+
+    {compress, opts} = Keyword.pop(opts, :compress, true)
+    ws_opts = %{compress: compress, protocols: [{"mqtt", :gun_ws_h}]}
+
+    args =
+      opts
+      |> Keyword.put(:host, host)
+      |> Keyword.put(:port, port)
+      |> Keyword.put(:timeout, timeout)
+      |> Keyword.put(:owner, owner)
+      |> Keyword.put(:owner_monitor_ref, ref)
+      |> Keyword.put_new(:transport, :tcp)
+      |> Keyword.put_new(:path, "/")
+      |> Keyword.put_new(:headers, [])
+      |> Keyword.put_new(:active, false)
+      |> Keyword.put(:ws_opts, ws_opts)
+
+    {:ok, :disconnected, struct(Data, args)}
+  end
+
+  def handle_event(
+        {:call, from},
+        :connect,
+        :disconnected,
+        %Data{
+          host: host,
+          port: port,
+          timeout: timeout,
+          transport: transport,
+          path: path,
+          headers: headers,
+          ws_opts: ws_opts
+        } = data
+      ) do
+    Logger.debug("[tortoise_websocket] Opening connection")
+
+    with start_time <- DateTime.utc_now(),
+         {:ok, socket} <-
+           Gun.open(host, port, %{
+             transport: transport,
+             connect_timeout: timeout,
+             protocols: [:http],
+             retry: 0
+           }),
+         timeout <- remaining_timeout(timeout, start_time),
+         {:ok, _} <- Gun.await_up(socket, timeout) do
+      Logger.debug("[tortoise_websocket] Upgrading connection")
+      Gun.ws_upgrade(socket, path, headers, ws_opts)
+
+      {:keep_state, %Data{data | caller: from},
+       {:state_timeout, remaining_timeout(timeout, start_time), {:upgrade_timeout, socket, from}}}
+    else
+      {:error, {:shutdown, :econnrefused}} ->
+        Logger.debug(
+          "[tortoise_websocket] It was not possible to connect to host #{inspect(host)} on port #{
+            port
+          }"
+        )
+
+        error = {:error, :econnrefused}
+        {:stop_and_reply, {:shutdown, error}, {:reply, from, error}}
+
+      {:error, {:shutdown, :closed}} ->
+        Logger.debug(
+          "[tortoise_websocket] It was not possible to connect to host #{inspect(host)} on port #{
+            port
+          }"
+        )
+
+        error = {:error, :closed}
+        {:stop_and_reply, {:shutdown, error}, {:reply, from, error}}
+
+      {:error, {:shutdown, :nxdomain}} ->
+        Logger.debug("[tortoise_websocket] Host #{host} not found")
+
+        error = {:error, :nxdomain}
+        {:stop_and_reply, {:shutdown, error}, {:reply, from, error}}
+
+      {:error, {:shutdown, :timeout}} ->
+        Logger.debug("[tortoise_websocket] Timeout while trying to connect")
+
+        error = {:error, :timeout}
+        {:stop_and_reply, {:shutdown, error}, {:reply, from, error}}
+
+      error ->
+        Logger.debug(
+          "[tortoise_websocket] There was an error while trying to connect: #{inspect(error)}"
+        )
+
+        {:stop_and_reply, {:shutdown, error}, {:reply, from, error}}
+    end
+  end
+
+  def handle_event({:call, from}, {:send, data}, {:connected, socket}, _) do
+    Gun.ws_send(socket, {:binary, data})
+    {:keep_state_and_data, {:reply, from, :ok}}
+  end
+
+  def handle_event(
+        {:call, from},
+        {:recv, length, timeout},
+        {:connected, _},
+        %Data{buffer: buffer, recv_queue: recv_queue} = data
+      ) do
+    cond do
+      length == 0 ->
+        {:keep_state, %Data{data | buffer: ""}, {:reply, from, {:ok, buffer}}}
+
+      byte_size(buffer) >= length ->
+        <<package::binary-size(length), rest::binary>> = buffer
+        {:keep_state, %Data{data | buffer: rest}, {:reply, from, {:ok, package}}}
+
+      true ->
+        {:keep_state, %Data{data | recv_queue: :queue.in({from, length}, recv_queue)},
+         {:timeout, timeout, {:recv_timeout, {from, length}}}}
+    end
+  end
+
+  def handle_event(
+        {:call, from},
+        {:owner, new_owner},
+        {:connected, _},
+        %Data{owner_monitor_ref: owner_monitor_ref} = data
+      ) do
+    Process.demonitor(owner_monitor_ref)
+    ref = Process.monitor(new_owner)
+    {:keep_state, %Data{data | owner: new_owner, owner_monitor_ref: ref}, {:reply, from, :ok}}
+  end
+
+  def handle_event({:call, from}, :close, state, _) do
+    case state do
+      {:connected, socket} -> Gun.close(socket)
+      _ -> :ok
+    end
+
+    {:stop_and_reply, :normal, {:reply, from, :ok}}
+  end
+
+  def handle_event({:call, from}, {:set_active, active}, {:connected, _}, data) do
+    {:keep_state, %Data{data | active: active}, {:reply, from, :ok}}
+  end
+
+  def handle_event({:call, from}, _, :disconnected, _) do
+    {:keep_state_and_data, {:reply, from, {:error, :not_connected}}}
+  end
+
+  def handle_event({:call, from}, _, _, _) do
+    {:keep_state_and_data, {:reply, from, {:error, :unexpected_command}}}
+  end
+
+  def handle_event(:cast, _, _, _) do
+    :keep_state_and_data
+  end
+
+  def handle_event(
+        :info,
+        {:gun_upgrade, socket, _, ["websocket"], _},
+        :disconnected,
+        %Data{caller: caller} = data
+      ) do
+    Logger.debug("[tortoise_websocket] Connection upgraded")
+
+    client_socket = %Socket{pid: self()}
+
+    {:next_state, {:connected, socket}, %Data{data | caller: nil, socket: client_socket},
+     {:reply, caller, {:ok, client_socket}}}
+  end
+
+  def handle_event(
+        :info,
+        {:gun_response, socket, _, _, status, _},
+        :disconnected,
+        %Data{caller: caller}
+      ) do
+    Logger.debug(
+      "[tortoise_websocket] It was not possible to upgrade connection, response status: #{
+        inspect(status)
+      }"
+    )
+
+    Gun.close(socket)
+    error = {:error, {:ws_upgrade_failed, "Response status: #{status}"}}
+    {:stop_and_reply, {:shutdown, error}, {:reply, caller, error}}
+  end
+
+  def handle_event(
+        :info,
+        {:gun_error, socket, _, reason},
+        :disconnected,
+        %Data{caller: caller}
+      ) do
+    Logger.debug(
+      "[tortoise_websocket] Error while trying to upgrade connection, reason: #{inspect(reason)}"
+    )
+
+    Gun.close(socket)
+    error = {:error, {:ws_upgrade_error, "Reason: #{inspect(reason)}"}}
+    {:stop_and_reply, {:shutdown, error}, {:reply, caller, error}}
+  end
+
+  def handle_event(
+        :info,
+        {:gun_down, socket, _, reason, _, _},
+        {:connected, socket},
+        %Data{owner: owner, socket: client_socket}
+      ) do
+    Logger.debug("[tortoise_websocket] Connection went down, reason: #{inspect(reason)}")
+    Kernel.send(owner, {:websocket_closed, client_socket})
+    {:stop, {:shutdown, {:error, :down}}}
+  end
+
+  def handle_event(
+        :info,
+        {:gun_ws, socket, _, :close},
+        {:connected, socket},
+        %Data{owner: owner, socket: client_socket}
+      ) do
+    Logger.debug("[tortoise_websocket] Server closed connection")
+    Kernel.send(owner, {:websocket_closed, client_socket})
+    {:stop, {:shutdown, {:error, :closed}}}
+  end
+
+  def handle_event(
+        :info,
+        {:gun_ws, _, _, {:binary, frame}},
+        {:connected, _},
+        %Data{
+          owner: owner,
+          active: active,
+          socket: socket,
+          buffer: buffer,
+          recv_queue: recv_queue
+        } = data
+      ) do
+    buffer = <<buffer::binary, frame::binary>>
+
+    {buffer, recv_queue} = satisfy_queued_recv(buffer, recv_queue)
+
+    case active do
+      true ->
+        Kernel.send(owner, {:websocket, socket, buffer})
+        {:keep_state, %Data{data | buffer: "", recv_queue: recv_queue}}
+
+      :once ->
+        Kernel.send(owner, {:websocket, socket, buffer})
+        {:keep_state, %Data{data | active: false, buffer: "", recv_queue: recv_queue}}
+
+      false ->
+        {:keep_state, %Data{data | buffer: buffer, recv_queue: recv_queue}}
+    end
+  end
+
+  def handle_event(:info, {:DOWN, owner_monitor_ref, :process, owner, _}, state, %Data{
+        owner: owner,
+        owner_monitor_ref: owner_monitor_ref
+      }) do
+    case state do
+      {:connected, socket} -> Gun.close(socket)
+      _ -> :ok
+    end
+
+    :stop
+  end
+
+  def handle_event(:info, msg, _, _) do
+    Logger.debug("[tortoise_websocket] Received unexpected message: #{inspect(msg)}")
+    :keep_state_and_data
+  end
+
+  def handle_event(:state_timeout, {:upgrade_timeout, socket, caller}, :disconnected, _) do
+    Logger.debug("[tortoise_websocket] Timeout while trying to upgrade connection")
+    Gun.close(socket)
+    error = {:error, :timeout}
+    {:stop_and_reply, {:shutdown, error}, {:reply, caller, error}}
+  end
+
+  def handle_event(
+        :timeout,
+        {:recv_timeout, {caller, length} = queued_recv},
+        {:connected, _},
+        %Data{recv_queue: recv_queue} = data
+      ) do
+    Logger.debug("[tortoise_websocket] Timeout while trying to receive data with #{length} bytes")
+    recv_queue = :queue.filter(&(&1 != queued_recv), recv_queue)
+    {:keep_state, %Data{data | recv_queue: recv_queue}, {:reply, caller, {:error, :timeout}}}
+  end
+
+  defp remaining_timeout(current_timeout, start_time),
+    do: max(current_timeout - time_since(start_time), 0)
+
+  defp time_since(datetime), do: DateTime.utc_now() |> DateTime.diff(datetime, :millisecond)
+
+  defp satisfy_queued_recv(buffer, recv_queue) do
+    recv_list = :queue.to_list(recv_queue)
+    {buffer, recv_remaining} = satisfy_recv_items(buffer, recv_list)
+    {buffer, :queue.from_list(recv_remaining)}
+  end
+
+  defp satisfy_recv_items(buffer, []), do: {buffer, []}
+
+  defp satisfy_recv_items(buffer, [{caller, 0} | remaining_items]) do
+    GenStateMachine.reply(caller, {:ok, buffer})
+    {"", remaining_items}
+  end
+
+  defp satisfy_recv_items(buffer, [{_, length} | _] = items) when byte_size(buffer) < length,
+    do: {buffer, items}
+
+  defp satisfy_recv_items(buffer, [{caller, length} | remaining_items]) do
+    <<data::binary-size(length), remaining_buffer::binary>> = buffer
+    GenStateMachine.reply(caller, {:ok, data})
+    satisfy_recv_items(remaining_buffer, remaining_items)
+  end
+end

--- a/lib/tortoise_websocket/client/socket.ex
+++ b/lib/tortoise_websocket/client/socket.ex
@@ -1,0 +1,5 @@
+defmodule TortoiseWebsocket.Client.Socket do
+  @type t() :: %__MODULE__{}
+
+  defstruct pid: nil
+end

--- a/lib/tortoise_websocket/client/supervisor.ex
+++ b/lib/tortoise_websocket/client/supervisor.ex
@@ -1,0 +1,18 @@
+defmodule TortoiseWebsocket.Client.Supervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+
+  def start_link(_) do
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(:ok) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_child(args) do
+    child_spec = TortoiseWebsocket.Client.child_spec(args)
+    DynamicSupervisor.start_child(__MODULE__, child_spec)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -26,10 +26,16 @@ defmodule TortoiseWebsocket.MixProject do
   end
 
   defp deps do
-    []
+    [
+      {:gen_state_machine, "~> 2.0"},
+      {:gun, "~> 1.3"},
+      {:socket, "~> 0.3"},
+      {:tortoise, github: "ejscunha/tortoise", branch: "feature/websocket-support"},
+      {:ex_doc, "~> 0.20", only: :dev, runtime: false}
+    ]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib"] ++ Path.wildcard("test/**/support")
   defp elixirc_paths(_), do: ["lib"]
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,12 @@
+%{
+  "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "gen_state_machine": {:hex, :gen_state_machine, "2.0.5", "9ac15ec6e66acac994cc442dcc2c6f9796cf380ec4b08267223014be1c728a95", [:mix], [], "hexpm"},
+  "gun": {:hex, :gun, "1.3.0", "18e5d269649c987af95aec309f68a27ffc3930531dd227a6eaa0884d6684286e", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"},
+  "tortoise": {:git, "https://github.com/ejscunha/tortoise.git", "dbdfebec46f7d3c9dc01c6f5c9c2777641c1c161", [branch: "feature/websocket-support"]},
+}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)

--- a/test/tortoise/support/scripted_mqtt_server.ex
+++ b/test/tortoise/support/scripted_mqtt_server.ex
@@ -1,0 +1,123 @@
+defmodule Tortoise.Support.ScriptedMqttServer do
+  # A helper for testing interactions with a MQTT server by setting up
+  # a process that act as the server and base its responses on a
+  # script of commands that are either send `{:send, package}`, or
+  # expected to be received `{:receive, package}`.
+
+  @moduledoc false
+
+  use GenServer
+
+  defstruct transport: nil,
+            server_socket: nil,
+            script: [],
+            client_pid: nil,
+            client: nil,
+            server_info: nil
+
+  alias Tortoise.Package
+  alias __MODULE__, as: State
+  alias Tortoise.Support.WebsocketFrameParser
+
+  # Client API
+  def start_link() do
+    start_link([])
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def enact(pid, script) do
+    GenServer.call(pid, {:enact, script})
+  end
+
+  # Server callbacks
+  def init(opts) do
+    transport = Tortoise.Transport.Websocket
+
+    transport_opts =
+      case Keyword.get(opts, :opts, :default) do
+        :default ->
+          [:binary, active: false, packet: :raw]
+
+        opts_list when is_list(opts_list) ->
+          opts_list
+      end
+
+    case transport.listen(transport_opts) do
+      {:ok, socket} ->
+        {:ok, server_info} = transport.sockname(socket)
+
+        initial_state = %__MODULE__{
+          server_info: server_info,
+          transport: transport,
+          server_socket: socket
+        }
+
+        {:ok, initial_state}
+    end
+  end
+
+  def handle_call({:enact, script}, {pid, _} = caller, state) do
+    GenServer.reply(caller, {:ok, state.server_info})
+    {:ok, client} = state.transport.accept(state.server_socket, 200)
+    :ok = state.transport.accept_ack(client, 200)
+    :ok = state.transport.setopts(client, active: :once)
+    next_action(%State{state | client_pid: pid, script: script, client: client})
+  end
+
+  def handle_info(
+        {transport, _, data},
+        %State{script: [{:receive, expected} | script]} = state
+      )
+      when transport in [:tcp, :ssl] do
+    case data |> WebsocketFrameParser.parse() |> Package.decode() do
+      ^expected ->
+        send(state.client_pid, {__MODULE__, {:received, expected}})
+        next_action(%State{state | script: script})
+
+      otherwise ->
+        throw({:unexpected_package, otherwise})
+    end
+  end
+
+  def handle_info({transport, client}, %State{script: [], client: client} = state)
+      when transport in [:tcp_closed, :ssl_closed] do
+    {:stop, :normal, state}
+  end
+
+  defp next_action(%State{script: [{:send, package} | remaining]} = state) do
+    # send the package right away
+    encoded_package = Package.encode(package)
+    :ok = state.transport.send(state.client, encoded_package)
+    next_action(%State{state | script: remaining})
+  end
+
+  defp next_action(%State{script: [{:receive, _} | _]} = state) do
+    :ok = state.transport.setopts(state.client, active: :once)
+    # keep state and await for client to send data
+    {:noreply, state}
+  end
+
+  defp next_action(%State{script: [:disconnect | remaining]} = state) do
+    :ok = state.transport.close(state.client)
+    {:ok, client} = state.transport.accept(state.server_socket, 200)
+    :ok = state.transport.setopts(client, active: :once)
+    next_action(%State{state | script: remaining, client: client})
+  end
+
+  defp next_action(%State{script: [:pause | remaining]} = state) do
+    send(state.client_pid, {__MODULE__, :paused})
+
+    receive do
+      :continue ->
+        next_action(%State{state | script: remaining})
+    end
+  end
+
+  defp next_action(%State{script: []} = state) do
+    send(state.client_pid, {__MODULE__, :completed})
+    {:noreply, state}
+  end
+end

--- a/test/tortoise/support/websocket_frame_parser.ex
+++ b/test/tortoise/support/websocket_frame_parser.ex
@@ -1,0 +1,44 @@
+defmodule Tortoise.Support.WebsocketFrameParser do
+  use Bitwise
+
+  def parse(frame) do
+    <<_::8, mask::1, _::7, rest::binary>> = frame
+
+    if mask == 1 do
+      <<key::32, data::binary>> = rest
+      unmask(key, data)
+    else
+      rest
+    end
+  end
+
+  defp unmask(key, data) do
+    unmask(key, data, <<>>)
+  end
+
+  defp unmask(key, <<data::32, rest::binary>>, acc) do
+    unmask(key, rest, <<acc::binary, data ^^^ key::32>>)
+  end
+
+  defp unmask(key, <<data::24>>, acc) do
+    <<key::24, _::8>> = <<key::32>>
+
+    unmask(key, <<>>, <<acc::binary, data ^^^ key::24>>)
+  end
+
+  defp unmask(key, <<data::16>>, acc) do
+    <<key::16, _::16>> = <<key::32>>
+
+    unmask(key, <<>>, <<acc::binary, data ^^^ key::16>>)
+  end
+
+  defp unmask(key, <<data::8>>, acc) do
+    <<key::8, _::24>> = <<key::32>>
+
+    unmask(key, <<>>, <<acc::binary, data ^^^ key::8>>)
+  end
+
+  defp unmask(_, <<>>, acc) do
+    acc
+  end
+end

--- a/test/tortoise/transport/websocket_test.exs
+++ b/test/tortoise/transport/websocket_test.exs
@@ -1,0 +1,377 @@
+defmodule Tortoise.Transport.WebsocketTest do
+  use ExUnit.Case, async: true
+  alias Tortoise.Support.ScriptedMqttServer
+  alias Tortoise.Connection
+  alias Tortoise.Package
+
+  setup context do
+    client_id = Atom.to_string(context.test)
+
+    {:ok, pid} = ScriptedMqttServer.start_link()
+
+    {:ok, %{client_id: client_id, scripted_mqtt_server: pid}}
+  end
+
+  describe "successful connect" do
+    test "without present state", context do
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id, clean_session: true}
+      expected_connack = %Package.Connack{status: :accepted, session_present: false}
+
+      script = [{:receive, connect}, {:send, expected_connack}]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, _pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+
+    test "reconnect with present state", context do
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id, clean_session: true}
+      reconnect = %Package.Connect{connect | clean_session: false}
+
+      script = [
+        {:receive, connect},
+        {:send, %Package.Connack{status: :accepted, session_present: false}},
+        :disconnect,
+        {:receive, reconnect},
+        {:send, %Package.Connack{status: :accepted, session_present: true}}
+      ]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, _pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, {:received, ^reconnect}}
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+  end
+
+  describe "unsuccessful connect" do
+    test "unacceptable protocol version", context do
+      Process.flag(:trap_exit, true)
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id}
+
+      script = [
+        {:receive, connect},
+        {:send, %Package.Connack{status: {:refused, :unacceptable_protocol_version}}}
+      ]
+
+      true = Process.unlink(context.scripted_mqtt_server)
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, pid} = Connection.start_link(opts)
+
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, :completed}
+      assert_receive {:EXIT, ^pid, {:connection_failed, :unacceptable_protocol_version}}
+    end
+
+    test "identifier rejected", context do
+      Process.flag(:trap_exit, true)
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id}
+      expected_connack = %Package.Connack{status: {:refused, :identifier_rejected}}
+
+      script = [{:receive, connect}, {:send, expected_connack}]
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, :completed}
+      assert_receive {:EXIT, ^pid, {:connection_failed, :identifier_rejected}}
+    end
+
+    test "server unavailable", context do
+      Process.flag(:trap_exit, true)
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id}
+      expected_connack = %Package.Connack{status: {:refused, :server_unavailable}}
+
+      script = [{:receive, connect}, {:send, expected_connack}]
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, :completed}
+      assert_receive {:EXIT, ^pid, {:connection_failed, :server_unavailable}}
+    end
+
+    test "bad user name or password", context do
+      Process.flag(:trap_exit, true)
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id}
+      expected_connack = %Package.Connack{status: {:refused, :bad_user_name_or_password}}
+
+      script = [{:receive, connect}, {:send, expected_connack}]
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, :completed}
+      assert_receive {:EXIT, ^pid, {:connection_failed, :bad_user_name_or_password}}
+    end
+
+    test "not authorized", context do
+      Process.flag(:trap_exit, true)
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id}
+      expected_connack = %Package.Connack{status: {:refused, :not_authorized}}
+
+      script = [{:receive, connect}, {:send, expected_connack}]
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, :completed}
+
+      assert_receive {:EXIT, ^pid, {:connection_failed, :not_authorized}}
+    end
+  end
+
+  describe "subscriptions" do
+    test "successful subscription", context do
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id, clean_session: true}
+      subscription_foo = Enum.into([{"foo", 0}], %Package.Subscribe{identifier: 1})
+      subscription_bar = Enum.into([{"bar", 1}], %Package.Subscribe{identifier: 2})
+      subscription_baz = Enum.into([{"baz", 2}], %Package.Subscribe{identifier: 3})
+
+      script = [
+        {:receive, connect},
+        {:send, %Package.Connack{status: :accepted, session_present: false}},
+        # subscribe to foo with qos 0
+        {:receive, subscription_foo},
+        {:send, %Package.Suback{identifier: 1, acks: [{:ok, 0}]}},
+        # subscribe to bar with qos 0
+        {:receive, subscription_bar},
+        {:send, %Package.Suback{identifier: 2, acks: [{:ok, 1}]}},
+        {:receive, subscription_baz},
+        {:send, %Package.Suback{identifier: 3, acks: [{:ok, 2}]}}
+      ]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      # connection
+      assert {:ok, _pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+
+      # subscribe to a foo
+      :ok = Tortoise.Connection.subscribe_sync(client_id, {"foo", 0}, identifier: 1)
+      assert_receive {ScriptedMqttServer, {:received, ^subscription_foo}}
+      assert Enum.member?(Tortoise.Connection.subscriptions(client_id), {"foo", 0})
+
+      # subscribe to a bar
+      assert {:ok, ref} = Tortoise.Connection.subscribe(client_id, {"bar", 1}, identifier: 2)
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
+      assert_receive {ScriptedMqttServer, {:received, ^subscription_bar}}
+
+      # subscribe to a baz
+      assert {:ok, ref} = Tortoise.Connection.subscribe(client_id, "baz", qos: 2, identifier: 3)
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
+      assert_receive {ScriptedMqttServer, {:received, ^subscription_baz}}
+
+      # foo, bar, and baz should now be in the subscription list
+      subscriptions = Tortoise.Connection.subscriptions(client_id)
+      assert Enum.member?(subscriptions, {"foo", 0})
+      assert Enum.member?(subscriptions, {"bar", 1})
+      assert Enum.member?(subscriptions, {"baz", 2})
+
+      # done
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+
+    test "successful unsubscribe", context do
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id, clean_session: true}
+      unsubscribe_foo = %Package.Unsubscribe{identifier: 2, topics: ["foo"]}
+      unsubscribe_bar = %Package.Unsubscribe{identifier: 3, topics: ["bar"]}
+
+      script = [
+        {:receive, connect},
+        {:send, %Package.Connack{status: :accepted, session_present: false}},
+        {:receive, %Package.Subscribe{topics: [{"foo", 0}, {"bar", 2}], identifier: 1}},
+        {:send, %Package.Suback{acks: [ok: 0, ok: 2], identifier: 1}},
+        # unsubscribe foo
+        {:receive, unsubscribe_foo},
+        {:send, %Package.Unsuback{identifier: 2}},
+        # unsubscribe bar
+        {:receive, unsubscribe_bar},
+        {:send, %Package.Unsuback{identifier: 3}}
+      ]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      subscribe = %Package.Subscribe{topics: [{"foo", 0}, {"bar", 2}], identifier: 1}
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []},
+        subscriptions: subscribe
+      ]
+
+      assert {:ok, _pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+
+      assert_receive {ScriptedMqttServer, {:received, ^subscribe}}
+
+      # now let us try to unsubscribe from foo
+      :ok = Tortoise.Connection.unsubscribe_sync(client_id, "foo", identifier: 2)
+      assert_receive {ScriptedMqttServer, {:received, ^unsubscribe_foo}}
+
+      assert %Package.Subscribe{topics: [{"bar", 2}]} =
+               Tortoise.Connection.subscriptions(client_id)
+
+      # and unsubscribe from bar
+      assert {:ok, ref} = Tortoise.Connection.unsubscribe(client_id, "bar", identifier: 3)
+      assert_receive {{Tortoise, ^client_id}, ^ref, :ok}
+      assert_receive {ScriptedMqttServer, {:received, ^unsubscribe_bar}}
+      assert %Package.Subscribe{topics: []} = Tortoise.Connection.subscriptions(client_id)
+
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+  end
+
+  describe "socket subscription" do
+    test "receive a socket from a connection", context do
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id, clean_session: true}
+      expected_connack = %Package.Connack{status: :accepted, session_present: false}
+
+      script = [{:receive, connect}, {:send, expected_connack}]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, _pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+
+      assert {:ok, {Tortoise.Transport.Websocket, _socket}} =
+               Connection.connection(client_id, timeout: 500)
+
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+
+    test "timeout on a socket from a connection", context do
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id, clean_session: true}
+
+      script = [{:receive, connect}, :pause]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, _pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+      assert_receive {ScriptedMqttServer, :paused}
+
+      assert {:error, :timeout} = Connection.connection(client_id, timeout: 5)
+
+      send(context.scripted_mqtt_server, :continue)
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+  end
+
+  describe "life-cycle" do
+    test "connect and cleanly disconnect", context do
+      Process.flag(:trap_exit, true)
+      client_id = context.client_id
+
+      connect = %Package.Connect{client_id: client_id}
+      expected_connack = %Package.Connack{status: :accepted, session_present: false}
+      disconnect = %Package.Disconnect{}
+
+      script = [{:receive, connect}, {:send, expected_connack}, {:receive, disconnect}]
+
+      {:ok, {ip, port}} = ScriptedMqttServer.enact(context.scripted_mqtt_server, script)
+
+      opts = [
+        client_id: client_id,
+        server: {Tortoise.Transport.Websocket, [host: ip, port: port]},
+        handler: {Tortoise.Handler.Default, []}
+      ]
+
+      assert {:ok, pid} = Connection.start_link(opts)
+      assert_receive {ScriptedMqttServer, {:received, ^connect}}
+
+      assert :ok = Tortoise.Connection.disconnect(client_id)
+      assert_receive {ScriptedMqttServer, {:received, ^disconnect}}
+      assert_receive {:EXIT, ^pid, :shutdown}
+
+      assert_receive {ScriptedMqttServer, :completed}
+    end
+  end
+end

--- a/test/tortoise_websocket/client_test.exs
+++ b/test/tortoise_websocket/client_test.exs
@@ -1,0 +1,160 @@
+defmodule TortoiseWebsocket.ClientTest do
+  use ExUnit.Case
+  alias TortoiseWebsocket.Client
+  alias TortoiseWebsocket.Support.WebsocketServer
+
+  @host 'localhost'
+
+  setup context do
+    port = Enum.random(49152..65535)
+
+    opts =
+      context
+      |> Map.get(:opts, [])
+      |> Keyword.put(:port, port)
+
+    {:ok, server_pid} = start_supervised({WebsocketServer, opts})
+    {:ok, port: port, server_pid: server_pid}
+  end
+
+  test "#connect it connects to the server and returns {:ok, socket}", %{port: port} do
+    assert {:ok, %Client.Socket{pid: pid}} = Client.connect(@host, port)
+    assert is_pid(pid)
+  end
+
+  test "#connect if the server is not available in the given port it returns {:error, :econnrefused}",
+       %{
+         port: port
+       } do
+    assert {:error, :econnrefused} = Client.connect(@host, port - 1)
+  end
+
+  @tag opts: [delay: 2]
+  test "#connect if the connection exceeds the timeout it returns {:error, :timeout}", %{
+    port: port,
+    opts: opts
+  } do
+    assert {:error, :timeout} = Client.connect(@host, port, [], opts[:delay] - 1)
+  end
+
+  test "#connect if the host can not be resolved it retuns {:error, :nxdomain}", %{
+    port: port
+  } do
+    assert {:error, :nxdomain} = Client.connect('invalid', port)
+  end
+
+  test "#send it sends binary data to the websocket server and returns :ok", %{
+    port: port,
+    server_pid: server_pid
+  } do
+    data = "data"
+    {:ok, socket} = Client.connect(@host, port)
+    assert :ok = Client.send(socket, data)
+    Process.sleep(10)
+    assert WebsocketServer.received?(server_pid, data)
+  end
+
+  test "#recv it receives binary data with the provided length from the websocket server and returns {:ok, data}",
+       %{
+         port: port,
+         server_pid: server_pid
+       } do
+    data = "data"
+    {:ok, socket} = Client.connect(@host, port)
+    WebsocketServer.send(server_pid, data)
+    assert {:ok, ^data} = Client.recv(socket, byte_size(data))
+  end
+
+  test "#recv it returns binary data equivalent to the provided length in bytes",
+       %{
+         port: port,
+         server_pid: server_pid
+       } do
+    data = "datadata"
+    expected_received_data = "data"
+    expected_received_data_length = byte_size(expected_received_data)
+    {:ok, socket} = Client.connect(@host, port)
+    WebsocketServer.send(server_pid, data)
+    assert {:ok, ^expected_received_data} = Client.recv(socket, expected_received_data_length)
+    assert {:ok, ^expected_received_data} = Client.recv(socket, expected_received_data_length)
+  end
+
+  test "#recv if the provided length is 0 it returns all data present in the server",
+       %{
+         port: port,
+         server_pid: server_pid
+       } do
+    data = "data"
+    {:ok, socket} = Client.connect(@host, port)
+    WebsocketServer.send(server_pid, data)
+    Process.sleep(10)
+    assert {:ok, ^data} = Client.recv(socket, 0)
+  end
+
+  test "#recv if the provided timeout is exceeded it returns {:error, :timeout}", %{port: port} do
+    {:ok, socket} = Client.connect(@host, port)
+    assert {:error, :timeout} = Client.recv(socket, 1, 10)
+  end
+
+  test "#controlling_process it changes the owning process of the client and returns :ok", %{
+    port: port,
+    server_pid: server_pid
+  } do
+    {:ok, socket} = Client.connect(@host, port, active: true)
+    test_pid = self()
+    data = "data"
+
+    new_owner =
+      spawn(fn ->
+        receive do
+          msg -> send(test_pid, msg)
+        end
+      end)
+
+    assert :ok = Client.controlling_process(socket, new_owner)
+    WebsocketServer.send(server_pid, data)
+
+    assert_receive({:websocket, ^socket, ^data})
+  end
+
+  test "#close it closes the connection to the server and stops the client and returns :ok", %{
+    port: port
+  } do
+    {:ok, socket} = Client.connect(@host, port)
+    assert :ok = Client.close(socket)
+    assert {:error, :closed} = Client.send(socket, "data")
+  end
+
+  test "#set_active it defines the client active mode and returns :ok", %{
+    port: port,
+    server_pid: server_pid
+  } do
+    data = "data"
+    {:ok, socket} = Client.connect(@host, port, active: false)
+
+    assert :ok = Client.set_active(socket, true)
+    WebsocketServer.send(server_pid, data)
+    assert_receive({:websocket, ^socket, ^data})
+    WebsocketServer.send(server_pid, data)
+    assert_receive({:websocket, ^socket, ^data})
+
+    assert :ok = Client.set_active(socket, false)
+    WebsocketServer.send(server_pid, data)
+    refute_receive({:websocket, ^socket, ^data}, 10)
+    assert {:ok, ^data} = Client.recv(socket, 0)
+
+    assert :ok = Client.set_active(socket, :once)
+    WebsocketServer.send(server_pid, data)
+    assert_receive({:websocket, ^socket, ^data})
+    WebsocketServer.send(server_pid, data)
+    refute_receive({:websocket, ^socket, ^data}, 10)
+    assert {:ok, ^data} = Client.recv(socket, 0)
+  end
+
+  test "if server closes the connection, the client sends the message {:websocket_closed, socket} to the owner",
+       %{port: port, server_pid: server_pid} do
+    {:ok, socket} = Client.connect(@host, port, active: false)
+    WebsocketServer.close(server_pid)
+    assert_receive({:websocket_closed, ^socket})
+  end
+end

--- a/test/tortoise_websocket/support/websocket_server.ex
+++ b/test/tortoise_websocket/support/websocket_server.ex
@@ -1,0 +1,84 @@
+defmodule TortoiseWebsocket.Support.WebsocketServer do
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def send(pid, data) do
+    GenServer.call(pid, {:send, data})
+  end
+
+  def received?(pid, data) do
+    GenServer.call(pid, {:received?, data})
+  end
+
+  def listen_connection(pid) do
+    Kernel.send(pid, :listen_connection)
+  end
+
+  def close(pid) do
+    GenServer.call(pid, :close)
+  end
+
+  def init(opts) do
+    port = Keyword.fetch!(opts, :port)
+    delay = Keyword.get(opts, :delay, false)
+    path = Keyword.get(opts, :path, "/")
+    Kernel.send(self(), :listen_connection)
+    {:ok, %{port: port, delay: delay, path: path, socket: nil, received: MapSet.new()}}
+  end
+
+  def handle_info(:listen_connection, %{port: port, delay: delay, path: path} = state) do
+    {:ok, listen_socket} = Socket.Web.listen(port)
+    {:ok, socket} = Socket.Web.accept(listen_socket)
+
+    if path == socket.path do
+      handle_delay(delay)
+      Socket.Web.accept!(socket)
+      receive_loop(socket, self())
+      {:noreply, %{state | socket: socket}}
+    else
+      Socket.Web.close(socket)
+      Kernel.send(self(), :listen_connection)
+      {:noreply, state}
+    end
+  end
+
+  def handle_info({:data, data}, %{received: received} = state) do
+    {:noreply, %{state | received: MapSet.put(received, data)}}
+  end
+
+  def handle_call({:send, data}, _, %{socket: socket} = state) do
+    Socket.Web.send(socket, {:binary, data})
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:received?, data}, _, %{received: received} = state) do
+    {:reply, MapSet.member?(received, data), state}
+  end
+
+  def handle_call(:close, _, %{socket: socket} = state) do
+    Socket.Web.close(socket)
+    {:reply, :ok, state}
+  end
+
+  defp handle_delay(delay) do
+    if is_integer(delay) do
+      Process.sleep(delay)
+    end
+  end
+
+  defp receive_loop(socket, server_pid) do
+    spawn(fn ->
+      case Socket.Web.recv!(socket) do
+        {:binary, data} ->
+          Kernel.send(server_pid, {:data, data})
+          receive_loop(socket, server_pid)
+
+        _ ->
+          :ok
+      end
+    end)
+  end
+end


### PR DESCRIPTION
This commit adds Tortoise websockets transport module.
For tests purposes the socket lib is used to mock a websocket server.
